### PR TITLE
Avoid re-initializing Remoting and Sitelet middleware on every call, without changing middleware types

### DIFF
--- a/WebSharper.Owin/Owin.Sitelets.fs
+++ b/WebSharper.Owin/Owin.Sitelets.fs
@@ -410,17 +410,17 @@ type RemotingMiddleware(next: AppFunc, webRoot: string, server: Rem.Server) =
 
     // (webRoot, ?binDirectory)
 
-    new (next, webRoot: string, ?binDirectory: string) =
+    static member UseRemoting(webRoot: string, ?binDirectory: string) =
         let meta =
             match binDirectory with
             | None -> M.Info.LoadFromWebRoot(webRoot)
             | Some binDirectory -> M.Info.LoadFromBinDirectory(binDirectory)
         let o = Options.Create(meta).WithServerRootDirectory(webRoot)
-        new RemotingMiddleware(next, o)
+        fun next -> new RemotingMiddleware(next, o)
 
     static member AsMidFunc(webRoot: string, ?binDirectory: string) =
-        MidFunc(fun next ->
-            AppFunc(RemotingMiddleware(next, webRoot, ?binDirectory = binDirectory).Invoke))
+        let mw = RemotingMiddleware.UseRemoting(webRoot, ?binDirectory = binDirectory)
+        MidFunc(fun next -> AppFunc(mw(next).Invoke))
 
 type SiteletMiddleware<'T when 'T : equality>(next: AppFunc, config: Options, sitelet: Sitelet<'T>) =
     let cb = ContextBuilder(config)

--- a/WebSharper.Owin/Owin.Sitelets.fsi
+++ b/WebSharper.Owin/Owin.Sitelets.fsi
@@ -56,7 +56,7 @@ type RemotingMiddleware =
     /// client-side code to invoke [<Rpc>]-annotated server-side functions.
     /// WebSharper metadata is loaded from binDirectory.
     /// If binDirectory is not specified, webRoot/bin is used.
-    new : next: AppFunc * webRoot: string * ?binDirectory: string -> RemotingMiddleware
+    static member UseRemoting : webRoot: string * ?binDirectory: string -> (AppFunc -> RemotingMiddleware)
     /// Runs the WebSharper Remoting service, allowing WebSharper-compiled
     /// client-side code to invoke [<Rpc>]-annotated server-side functions.
     /// WebSharper metadata is loaded from binDirectory.

--- a/WebSharper.Owin/Owin.Sitelets.fsi
+++ b/WebSharper.Owin/Owin.Sitelets.fsi
@@ -72,22 +72,11 @@ type SiteletMiddleware<'T when 'T : equality> =
     /// Runs the provided Sitelet with the provided options.
     static member AsMidFunc : config: Options * sitelet: Sitelet<'T> -> MidFunc
 
-    /// Runs the provided Sitelet with webRoot as the root folder, using
-    /// WebSharper metadata loaded from assemblies located in binDirectory.
-    /// Also runs the Remoting service using metadata discovered from binDirectory.
-    /// If binDirectory is not specified, webRoot/bin is used.
-    new : next: AppFunc * webRoot: string * sitelet: Sitelet<'T> * ?binDirectory: string -> SiteletMiddleware<'T>
-    /// Runs the provided Sitelet with webRoot as the root folder, using
-    /// WebSharper metadata loaded from assemblies located in binDirectory.
-    /// Also runs the Remoting service using metadata discovered from binDirectory.
-    /// If binDirectory is not specified, webRoot/bin is used.
-    static member AsMidFunc : webRoot: string * sitelet: Sitelet<'T> * ?binDirectory: string -> MidFunc
-
     /// Inspects the binDirectory folder, looking for an assembly that contains
     /// a WebSharper Sitelet, and runs this Sitelet with webRoot as the root folder.
     /// Also runs the Remoting service using metadata discovered from binDirectory.
     /// If binDirectory is not specified, webRoot/bin is used.
-    static member Create : webRoot: string * ?binDirectory: string -> (AppFunc -> SiteletMiddleware<obj>)
+    static member UseDiscoveredSitelet : webRoot: string * ?binDirectory: string -> (AppFunc -> SiteletMiddleware<obj>)
     /// Inspects the binDirectory folder, looking for an assembly that contains
     /// a WebSharper Sitelet, and runs this Sitelet with webRoot as the root folder.
     /// Also runs the Remoting service using metadata discovered from binDirectory.

--- a/WebSharper.Owin/Owin.Sitelets.fsi
+++ b/WebSharper.Owin/Owin.Sitelets.fsi
@@ -54,13 +54,6 @@ type RemotingMiddleware =
 
     /// Runs the WebSharper Remoting service, allowing WebSharper-compiled
     /// client-side code to invoke [<Rpc>]-annotated server-side functions.
-    new : next: AppFunc * webRoot: string * meta: M.Info -> RemotingMiddleware
-    /// Runs the WebSharper Remoting service, allowing WebSharper-compiled
-    /// client-side code to invoke [<Rpc>]-annotated server-side functions.
-    static member AsMidFunc : webRoot: string * meta: M.Info -> MidFunc
-
-    /// Runs the WebSharper Remoting service, allowing WebSharper-compiled
-    /// client-side code to invoke [<Rpc>]-annotated server-side functions.
     /// WebSharper metadata is loaded from binDirectory.
     /// If binDirectory is not specified, webRoot/bin is used.
     new : next: AppFunc * webRoot: string * ?binDirectory: string -> RemotingMiddleware

--- a/WebSharper.Owin/Owin.Sitelets.fsi
+++ b/WebSharper.Owin/Owin.Sitelets.fsi
@@ -87,7 +87,7 @@ type SiteletMiddleware<'T when 'T : equality> =
     /// a WebSharper Sitelet, and runs this Sitelet with webRoot as the root folder.
     /// Also runs the Remoting service using metadata discovered from binDirectory.
     /// If binDirectory is not specified, webRoot/bin is used.
-    static member Create : next: AppFunc * webRoot: string * ?binDirectory: string -> SiteletMiddleware<obj>
+    static member Create : webRoot: string * ?binDirectory: string -> (AppFunc -> SiteletMiddleware<obj>)
     /// Inspects the binDirectory folder, looking for an assembly that contains
     /// a WebSharper Sitelet, and runs this Sitelet with webRoot as the root folder.
     /// Also runs the Remoting service using metadata discovered from binDirectory.


### PR DESCRIPTION
See the discussion [here](https://github.com/intellifactory/websharper.owin/pull/5): this is an alternate implementation based on [this websharper change](https://github.com/intellifactory/websharper/pull/380) that moves the creation of the remoting server from the middleware to `Options`.